### PR TITLE
fix(ci): add missing checkout step in upload-macos-assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,8 @@ jobs:
     needs: build-macos
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Download Darwin archives
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
gh release commands require git repository context to work properly.